### PR TITLE
Added type annotations to functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 *config.yml
 *.log
 .coverage
+.mypy_cache

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,3 @@
 [mypy]
 ignore_missing_imports = True
+disallow_untyped_defs = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,11 @@ discord.py==1.3.3
 docopt==0.6.2
 idna==2.9
 multidict==4.7.5
+mypy==0.770
+mypy-extensions==0.4.3
 PyYAML==5.3.1
 testfixtures==6.14.1
+typed-ast==1.4.1
+typing-extensions==3.7.4.2
 websockets==8.1
 yarl==1.4.2

--- a/src/bot.py
+++ b/src/bot.py
@@ -1,5 +1,5 @@
 import logging
-from collections import namedtuple
+from typing import Dict, Any, List, Optional
 
 import discord
 
@@ -10,46 +10,46 @@ from event.on_raw_reaction_remove import on_raw_reaction_remove
 from log import init_logger
 from util.embed import create_overview_info_embed, create_lecture_embed, get_embed_with_title, \
     embed_in_message_needs_update
-from util.lecture import populate_lectures_in_config
+from util.lecture import populate_lectures_in_config, LectureMessage, Lecture
 
 
 class BotClient(discord.Client):
 
-    def __init__(self, config=None, **options):
+    def __init__(self, config: Dict[str, Any], **options: Any):
         init_logger()
         super().__init__(**options)
         self.config = config
         self.config['lectures'] = populate_lectures_in_config(self.config['lectures'])
-        self.lecture_message_tuples = []
-        self.guild = None
-        self.logger = logging.getLogger('bot')
+        self.lecture_messages: List[LectureMessage] = []
+        self.guild: Optional[discord.Guild] = None
+        self.logger: logging.Logger = logging.getLogger('bot')
 
-    async def on_ready(self):
+    async def on_ready(self) -> None:
         """Executed when bot is logged in and ready."""
         self.logger.info('Logged in as %s with id %s' % (self.user.name, self.user.id))
 
-    async def on_member_join(self, member):
+    async def on_member_join(self, member: discord.Member) -> None:
         await on_member_join(self)(member)
 
-    async def on_raw_reaction_add(self, raw_reaction):
+    async def on_raw_reaction_add(self, raw_reaction: discord.RawReactionActionEvent) -> None:
         await on_raw_reaction_add(self)(raw_reaction)
 
-    async def on_raw_reaction_remove(self, raw_reaction):
+    async def on_raw_reaction_remove(self, raw_reaction: discord.RawReactionActionEvent) -> None:
         await on_raw_reaction_remove(self)(raw_reaction)
 
-    def get_lecture_of_message_id(self, message_id):
+    def get_lecture_of_message_id(self, message_id: int) -> Optional[Lecture]:
         """Returns the lecture associated with this message if there is one. Else returns None."""
-        for tuples in self.lecture_message_tuples:
-            if tuples.message_id == message_id:
-                return tuples.lecture
+        for lecture_message in self.lecture_messages:
+            if lecture_message.message_id == message_id:
+                return lecture_message.lecture
         return None
 
-    async def _init_lecture_embed(self, channel, lecture):
+    async def _init_lecture_embed(self, channel: discord.TextChannel, lecture: Lecture) -> discord.Message:
         """Returns the message for this lecture in the given channel.
         If it does not exist yet, it will be created."""
-        message = await get_embed_with_title(channel, lecture.embed_title)
-        guild = await self._guild()
-        embed = create_lecture_embed(guild, lecture)
+        message: discord.Message = await get_embed_with_title(channel, lecture.embed_title)
+        guild: discord.Guild = await self._guild()
+        embed: discord.Embed = create_lecture_embed(guild, lecture)
         if message is None:
             message = await channel.send(embed=embed)
             await message.add_reaction(WHITE_CHECK_MARK)
@@ -60,17 +60,17 @@ class BotClient(discord.Client):
             self.logger.info('Updated embed for lecture %s' % lecture.embed_title)
         return message
 
-    async def _guild(self):
+    async def _guild(self) -> discord.Guild:
         """Returns the guild instance for which the config of this bot instance is written for.
         Also caches the result so we won't have to fetch again."""
         if self.guild is None:
             self.guild = self.get_guild(int(self.config['guild']))
         return self.guild
 
-    async def _init_overview_embed(self, channel):
+    async def _init_overview_embed(self, channel: discord.TextChannel) -> discord.Message:
         """Creates the overview embed in the given channel.
         The overview embed lists all available lectures and has some user information in it."""
-        embed = create_overview_info_embed()
+        embed: discord.Embed = create_overview_info_embed()
         message = await get_embed_with_title(channel, embed.title)
         if message is None:
             await channel.send(embed=embed)
@@ -80,15 +80,14 @@ class BotClient(discord.Client):
             self.logger.info('Updated overview embed')
         return message
 
-    async def init_overview_channel(self):
+    async def init_overview_channel(self) -> None:
         """Initializes the overview channel.
         Makes sure that an embed for every lecture exists such that users can react to it and
         the role can be assigned."""
-        lecture_tuple = namedtuple('LectureMessage', 'lecture message_id')
         await self.wait_until_ready()
-        overview_channel = await self.fetch_channel(self.config['overview'])
+        overview_channel: discord.TextChannel = await self.fetch_channel(self.config['overview'])
         await self._init_overview_embed(overview_channel)
         for lecture in self.config['lectures']:
-            message = await self._init_lecture_embed(overview_channel, lecture)
-            self.lecture_message_tuples.append(lecture_tuple(lecture=lecture, message_id=message.id))
+            message: discord.Message = await self._init_lecture_embed(overview_channel, lecture)
+            self.lecture_messages.append(LectureMessage(lecture=lecture, message_id=message.id))
             self.logger.info('Message with id %s holds the embed for lecture %s' % (message.id, lecture.embed_title))

--- a/src/const.py
+++ b/src/const.py
@@ -3,4 +3,4 @@ This file is used to score constants such as the unicode characters of reactions
 For example, the unicode character for :white_check_mark: is \u2705.
 """
 
-WHITE_CHECK_MARK = '\u2705'
+WHITE_CHECK_MARK: str = '\u2705'

--- a/src/event/on_member_join.py
+++ b/src/event/on_member_join.py
@@ -1,11 +1,12 @@
-from typing import Coroutine, Callable
+from typing import Coroutine, Callable, TYPE_CHECKING
 
 import discord
 
-from bot import BotClient
+if TYPE_CHECKING:
+    from bot import BotClient
 
 
-def on_member_join(bot: BotClient) -> Callable[[discord.Member], Coroutine]:
+def on_member_join(bot: 'BotClient') -> Callable[[discord.Member], Coroutine]:
     """Higher order function which returns the handler for the 'on_member_join' event."""
 
     async def handler(member: discord.Member) -> None:

--- a/src/event/on_member_join.py
+++ b/src/event/on_member_join.py
@@ -1,12 +1,16 @@
+from typing import Coroutine, Callable
+
 import discord
 
+from bot import BotClient
 
-def on_member_join(bot):
+
+def on_member_join(bot: BotClient) -> Callable[[discord.Member], Coroutine]:
     """Higher order function which returns the handler for the 'on_member_join' event."""
 
-    async def handler(member):
+    async def handler(member: discord.Member) -> None:
         """Greets new member."""
-        guild = member.guild
+        guild: discord.Guild = member.guild
         bot.logger.info('User %s has joined guild %s' % (member.user.name, member.guild))
         if guild.system_channel is not None:
             greeting = discord.Embed(

--- a/src/event/on_raw_reaction_add.py
+++ b/src/event/on_raw_reaction_add.py
@@ -1,8 +1,9 @@
-from typing import Callable, Coroutine, TYPE_CHECKING
+from typing import Callable, Coroutine, TYPE_CHECKING, Optional
 
 import discord
 
 from const import WHITE_CHECK_MARK
+from util.lecture import Lecture
 from util.member import add_role_to_member
 
 if TYPE_CHECKING:
@@ -27,10 +28,10 @@ def on_raw_reaction_add(bot: 'BotClient') -> Callable[[discord.RawReactionAction
         # check if reaction was the one we expect to for role assignment
         if emoji == WHITE_CHECK_MARK:
             # check if the reaction belongs to an lecture embed
-            lecture = bot.get_lecture_of_message_id(message_id)
+            lecture: Optional[Lecture] = bot.get_lecture_of_message_id(message_id)
             if lecture is not None:
                 bot.logger.info('Reaction was added to embed of lecture %s' % lecture.embed_title)
-                lecture_role_id = lecture.role
+                lecture_role_id: str = lecture.role
                 await add_role_to_member(member, lecture_role_id)
                 bot.logger.info("Role added!")
 

--- a/src/event/on_raw_reaction_add.py
+++ b/src/event/on_raw_reaction_add.py
@@ -27,8 +27,8 @@ def on_raw_reaction_add(bot: BotClient) -> Callable[[discord.RawReactionActionEv
             # check if the reaction belongs to an lecture embed
             lecture = bot.get_lecture_of_message_id(message_id)
             if lecture is not None:
-                bot.logger.info('Reaction was added to embed of lecture %s' % lecture['embed_title'])
-                lecture_role_id = lecture['role']
+                bot.logger.info('Reaction was added to embed of lecture %s' % lecture.embed_title)
+                lecture_role_id = lecture.role
                 await add_role_to_member(member, lecture_role_id)
                 bot.logger.info("Role added!")
 

--- a/src/event/on_raw_reaction_add.py
+++ b/src/event/on_raw_reaction_add.py
@@ -1,13 +1,15 @@
-from typing import Callable, Coroutine
+from typing import Callable, Coroutine, TYPE_CHECKING
 
 import discord
 
-from bot import BotClient
 from const import WHITE_CHECK_MARK
 from util.member import add_role_to_member
 
+if TYPE_CHECKING:
+    from bot import BotClient
 
-def on_raw_reaction_add(bot: BotClient) -> Callable[[discord.RawReactionActionEvent], Coroutine]:
+
+def on_raw_reaction_add(bot: 'BotClient') -> Callable[[discord.RawReactionActionEvent], Coroutine]:
     """Higher order  function which returns the handler for the 'on_raw_reaction_add' event."""
 
     async def handler(raw_reaction: discord.RawReactionActionEvent) -> None:

--- a/src/event/on_raw_reaction_add.py
+++ b/src/event/on_raw_reaction_add.py
@@ -1,20 +1,25 @@
+from typing import Callable, Coroutine
+
+import discord
+
+from bot import BotClient
 from const import WHITE_CHECK_MARK
 from util.member import add_role_to_member
 
 
-def on_raw_reaction_add(bot):
+def on_raw_reaction_add(bot: BotClient) -> Callable[[discord.RawReactionActionEvent], Coroutine]:
     """Higher order  function which returns the handler for the 'on_raw_reaction_add' event."""
 
-    async def handler(raw_reaction):
+    async def handler(raw_reaction: discord.RawReactionActionEvent) -> None:
         """If an user reacted appropriately to an lecture embed, the user is assigned the role associated
         with the lecture.
         """
         if raw_reaction.user_id == bot.user.id:
             # bot should not react to reactions from itself
             return
-        member = raw_reaction.member
-        emoji = raw_reaction.emoji.name
-        message_id = raw_reaction.message_id
+        member: discord.Member = raw_reaction.member
+        emoji: discord.Emoji = raw_reaction.emoji.name
+        message_id: int = raw_reaction.message_id
         # TODO populate logging info with actual message?
         bot.logger.info('User %s has reacted with %s to message with id %s' % (member, emoji, message_id))
         # check if reaction was the one we expect to for role assignment

--- a/src/event/on_raw_reaction_remove.py
+++ b/src/event/on_raw_reaction_remove.py
@@ -29,8 +29,8 @@ def on_raw_reaction_remove(bot: BotClient) -> Callable[[discord.RawReactionActio
             # check if the reaction belongs to an lecture embed
             lecture: Optional[Lecture] = bot.get_lecture_of_message_id(message_id)
             if lecture is not None:
-                bot.logger.info('Reaction was removed from embed of lecture %s' % lecture['embed_title'])
-                lecture_role_id: str = lecture['role']
+                bot.logger.info('Reaction was removed from embed of lecture %s' % lecture.embed_title)
+                lecture_role_id: str = lecture.role
                 await remove_role_from_member(member, lecture_role_id)
                 bot.logger.info("Role removed!")
 

--- a/src/event/on_raw_reaction_remove.py
+++ b/src/event/on_raw_reaction_remove.py
@@ -1,30 +1,36 @@
+from typing import Callable, Coroutine
+
+import discord
+
+from bot import BotClient
 from const import WHITE_CHECK_MARK
+from util.lecture import Lecture
 from util.member import remove_role_from_member
 
 
-def on_raw_reaction_remove(bot):
+def on_raw_reaction_remove(bot: BotClient) -> Callable[[discord.RawReactionActionEvent], Coroutine]:
     """Higher order  function which returns the handler for the 'on_raw_reaction_add' event."""
 
     # TODO this code is very similar to the one in `on_raw_reaction_add`
-    async def handler(raw_reaction):
+    async def handler(raw_reaction: discord.RawReactionActionEvent) -> None:
         """Handles users removing reactions from messages.
         If an user removed his previous reaction from a lecture embed, the associated role is removed."""
         if raw_reaction.user_id == bot.user.id:
             # bot should not react to reactions from itself
             return
-        guild = bot.get_guild(raw_reaction.guild_id)
-        member = guild.get_member(raw_reaction.user_id)
-        emoji = raw_reaction.emoji.name
-        message_id = raw_reaction.message_id
+        guild: discord.Guild = bot.get_guild(raw_reaction.guild_id)
+        member: discord.Member = guild.get_member(raw_reaction.user_id)
+        emoji: discord.Emoji = raw_reaction.emoji.name
+        message_id: int = raw_reaction.message_id
         # TODO populate logging info with actual message?
         bot.logger.info('User %s has removed reaction %s from message with id %s' % (member, emoji, message_id))
         # check if reaction was the one we expect to remove the role
         if emoji == WHITE_CHECK_MARK:  # \u2705 is :white_check_mark:
             # check if the reaction belongs to an lecture embed
-            lecture = bot.get_lecture_of_message_id(message_id)
+            lecture: Lecture = bot.get_lecture_of_message_id(message_id)
             if lecture is not None:
                 bot.logger.info('Reaction was removed from embed of lecture %s' % lecture['embed_title'])
-                lecture_role_id = lecture['role']
+                lecture_role_id: str = lecture['role']
                 await remove_role_from_member(member, lecture_role_id)
                 bot.logger.info("Role removed!")
 

--- a/src/event/on_raw_reaction_remove.py
+++ b/src/event/on_raw_reaction_remove.py
@@ -1,14 +1,16 @@
-from typing import Callable, Coroutine, Optional
+from typing import Callable, Coroutine, Optional, TYPE_CHECKING
 
 import discord
 
-from bot import BotClient
 from const import WHITE_CHECK_MARK
 from util.lecture import Lecture
 from util.member import remove_role_from_member
 
+if TYPE_CHECKING:
+    from bot import BotClient
 
-def on_raw_reaction_remove(bot: BotClient) -> Callable[[discord.RawReactionActionEvent], Coroutine]:
+
+def on_raw_reaction_remove(bot: 'BotClient') -> Callable[[discord.RawReactionActionEvent], Coroutine]:
     """Higher order  function which returns the handler for the 'on_raw_reaction_add' event."""
 
     # TODO this code is very similar to the one in `on_raw_reaction_add`

--- a/src/event/on_raw_reaction_remove.py
+++ b/src/event/on_raw_reaction_remove.py
@@ -19,7 +19,7 @@ def on_raw_reaction_remove(bot):
         # TODO populate logging info with actual message?
         bot.logger.info('User %s has removed reaction %s from message with id %s' % (member, emoji, message_id))
         # check if reaction was the one we expect to remove the role
-        if emoji == '\u2705':  # \u2705 is :white_check_mark:
+        if emoji == WHITE_CHECK_MARK:  # \u2705 is :white_check_mark:
             # check if the reaction belongs to an lecture embed
             lecture = bot.get_lecture_of_message_id(message_id)
             if lecture is not None:

--- a/src/event/on_raw_reaction_remove.py
+++ b/src/event/on_raw_reaction_remove.py
@@ -1,4 +1,4 @@
-from typing import Callable, Coroutine
+from typing import Callable, Coroutine, Optional
 
 import discord
 
@@ -27,7 +27,7 @@ def on_raw_reaction_remove(bot: BotClient) -> Callable[[discord.RawReactionActio
         # check if reaction was the one we expect to remove the role
         if emoji == WHITE_CHECK_MARK:  # \u2705 is :white_check_mark:
             # check if the reaction belongs to an lecture embed
-            lecture: Lecture = bot.get_lecture_of_message_id(message_id)
+            lecture: Optional[Lecture] = bot.get_lecture_of_message_id(message_id)
             if lecture is not None:
                 bot.logger.info('Reaction was removed from embed of lecture %s' % lecture['embed_title'])
                 lecture_role_id: str = lecture['role']

--- a/src/log.py
+++ b/src/log.py
@@ -5,12 +5,13 @@ import sys
 
 class MakeFileHandler(logging.FileHandler):
     """FileHandler class to automatically create folders needed for logs."""
-    def __init__(self, filename, mode='a', encoding='utf-8', delay=0):
+
+    def __init__(self, filename: str, mode: str = 'a', encoding: str = 'utf-8', delay: bool = False):
         os.makedirs(os.path.dirname(filename), exist_ok=True)
         super().__init__(filename, mode, encoding, delay)
 
 
-def init_bot_logger(path='logs/physicsbot.log'):
+def init_bot_logger(path: str = 'logs/physicsbot.log') -> None:
     bot_logger = logging.getLogger('bot')
     bot_logger.setLevel(logging.DEBUG)
     # TODO cmd option to clear log on startup?
@@ -21,7 +22,7 @@ def init_bot_logger(path='logs/physicsbot.log'):
     bot_logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
-def init_discord_logger(path='logs/discord.log'):
+def init_discord_logger(path: str = 'logs/discord.log') -> None:
     d_logger = logging.getLogger('discord')
     d_logger.setLevel(logging.DEBUG)
     # TODO cmd option to clear log on startup?
@@ -30,7 +31,7 @@ def init_discord_logger(path='logs/discord.log'):
     d_logger.addHandler(d_handler)
 
 
-def init_logger():
+def init_logger() -> None:
     """Initializes the discord logger and other loggers."""
     init_discord_logger()
     init_bot_logger()

--- a/src/main.py
+++ b/src/main.py
@@ -11,6 +11,7 @@ Usage:
 """
 
 from pathlib import Path
+from typing import Dict, Any
 
 import yaml
 from docopt import docopt
@@ -18,7 +19,7 @@ from docopt import docopt
 from bot import BotClient
 
 
-def start_bot(token, config):
+def start_bot(token: str, config: Dict[str, Any]) -> None:
     """Starts the bot and runs the guild initialisation process.
     Consists of making sure that for every lecture, there is an embed in the overview channel.
     """
@@ -27,13 +28,13 @@ def start_bot(token, config):
     bot.run(token)
 
 
-def main():
+def main() -> None:
     args = docopt(__doc__)
-    config_path = args['--config'] or str(Path(__file__).parent / '../dev.config.yml')
+    config_path: str = args['--config'] or str(Path(__file__).parent / '../dev.config.yml')
     with open(config_path, 'r') as file:
-        config = yaml.safe_load(file)
+        config: Dict[str, Any] = yaml.safe_load(file)
     if args['run']:
-        token = args['--token'] or config['token']
+        token: str = args['--token'] or config['token']
         start_bot(token, config)
 
 

--- a/src/util/embed.py
+++ b/src/util/embed.py
@@ -1,9 +1,12 @@
-from discord import Embed
+from typing import Optional
+
+import discord
 
 from const import WHITE_CHECK_MARK
+from util.lecture import Lecture
 
 
-def create_overview_info_embed():
+def create_overview_info_embed() -> discord.Embed:
     """Creates the info embed in the overview channel.
     The guild instance is needed for fetching roles and emojis."""
     # create embed description
@@ -20,38 +23,40 @@ def create_overview_info_embed():
     Dies ist auch reversibel; das heißt ihr könnt hier auch eine Rolle durch einfaches Klicken wieder entfernen, \
     um z.B. über LA oder ANA nicht mehr informiert zu werden bzw. diese Kanäle nicht mehr zu sehen.
     """
-    return Embed(
+    return discord.Embed(
         title="Rollen",
         description=desc
     )
 
 
-def create_lecture_embed(guild, lecture):
+def create_lecture_embed(guild: discord.Guild, lecture: Lecture) -> discord.Embed:
     """Creates the embed for the given lecture."""
-    role = guild.get_role(int(lecture.role))
-    desc = "{}\n".format(role.mention)
+    role: discord.Role = guild.get_role(int(lecture.role))
+    desc: str = "{}\n".format(role.mention)
     desc += "Du brauchst unbedingt diese Rolle? Dann gib mir hier ein {}!".format(WHITE_CHECK_MARK)
-    return Embed(
+    return discord.Embed(
         # the embed title must be assigned since that's how we will find it in `get_embed_with_title`
         title=lecture.embed_title,
         description=desc
     )
 
 
-def embed_in_message_needs_update(message, embed):
+def embed_in_message_needs_update(message: discord.Message, embed: discord.Embed) -> bool:
     """Check if the embed of the given message needs an update. The given embed is the up-to-date version.
     Comparison is done by checking if the embed title and description do match."""
     if len(message.embeds) == 0:
         return True
     if len(message.embeds) > 1:
         raise RuntimeWarning("Called needs_update with message which contains multiple embeds.")
-    old_embed = message.embeds[0]
+    old_embed: discord.Embed = message.embeds[0]
     return old_embed.title != embed.title or old_embed.description != embed.description
 
 
-async def get_embed_with_title(channel, embed_title):
+async def get_embed_with_title(channel: discord.TextChannel, embed_title: str) -> Optional[discord.Message]:
     """Returns the message in the given channel which has an embed with the given title if it exists else None"""
+    message: discord.Message
     async for message in channel.history(limit=100):
+        embed: discord.Embed
         for embed in message.embeds:
             if embed.title == embed_title:
                 return message

--- a/src/util/lecture.py
+++ b/src/util/lecture.py
@@ -12,6 +12,12 @@ class Lecture:
     channel: str  # id of channel this lecture is associated with
 
 
+@dataclass
+class LectureMessage:
+    message_id: int  # the id of the message
+    lecture: Lecture  # the associated lecture
+
+
 def populate_lectures_in_config(config_lectures):
     """This function "populates" the lectures list in the configuration into a list of actual
     Lecture objects with which we can work in a more handy way.

--- a/src/util/lecture.py
+++ b/src/util/lecture.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from dataclasses import dataclass
+from typing import Dict, List, Any
 
 
 @dataclass
@@ -18,23 +19,23 @@ class LectureMessage:
     lecture: Lecture  # the associated lecture
 
 
-def populate_lectures_in_config(config_lectures):
+def populate_lectures_in_config(config_lectures: List[Dict[str, str]]) -> List[Lecture]:
     """This function "populates" the lectures list in the configuration into a list of actual
     Lecture objects with which we can work in a more handy way.
     Following keys are mandatory: 'name', 'role', 'embed_title'
     Following keys are optional: 'emoji', 'channel'"""
     mandatory_members = ['name', 'role', 'embed_title']
 
-    def create_lecture_default_dict(lecture):
-        class LectureDefaultDict(defaultdict):
-            """Implements the mandatory and optional specification of lecture members."""
+    class LectureDefaultDict(defaultdict):
+        """Implements the mandatory and optional specification of lecture members."""
 
-            def __missing__(self, key):
-                if key in mandatory_members:
-                    raise KeyError
-                return self.default_factory
+        def __missing__(self, key: str) -> Any:
+            if key in mandatory_members:
+                raise KeyError
+            return self.default_factory
 
-        return LectureDefaultDict(None, [*lecture.items()])
+    def create_lecture_default_dict(lecture: Dict[str, str]) -> LectureDefaultDict:
+        return LectureDefaultDict(None, [*lecture.items()])  # type: ignore
 
     return [
         Lecture(l['name'], l['role'], l['emoji'], l['embed_title'], l['channel'])

--- a/src/util/member.py
+++ b/src/util/member.py
@@ -1,12 +1,15 @@
-async def add_role_to_member(member, role_id):
+import discord
+
+
+async def add_role_to_member(member: discord.Member, role_id: int) -> None:
     """Adds the role given by its id to the member.
     The role id must be from a role of the guild of the member (if that's not obvious)"""
-    role = member.guild.get_role(int(role_id))
+    role: discord.Role = member.guild.get_role(int(role_id))
     await member.add_roles(role)
 
 
-async def remove_role_from_member(member, role_id):
+async def remove_role_from_member(member: discord.Member, role_id: int) -> None:
     """Removes the role given by its id from the member.
     The role id must be from a role of the guild of the member (if that's not obvious)"""
-    role = member.guild.get_role(int(role_id))
+    role: discord.Role = member.guild.get_role(int(role_id))
     await member.remove_roles(role)

--- a/src/util/member.py
+++ b/src/util/member.py
@@ -1,14 +1,16 @@
+from typing import Union
+
 import discord
 
 
-async def add_role_to_member(member: discord.Member, role_id: int) -> None:
+async def add_role_to_member(member: discord.Member, role_id: Union[str, int]) -> None:
     """Adds the role given by its id to the member.
     The role id must be from a role of the guild of the member (if that's not obvious)"""
     role: discord.Role = member.guild.get_role(int(role_id))
     await member.add_roles(role)
 
 
-async def remove_role_from_member(member: discord.Member, role_id: int) -> None:
+async def remove_role_from_member(member: discord.Member, role_id: Union[str, int]) -> None:
     """Removes the role given by its id from the member.
     The role id must be from a role of the guild of the member (if that's not obvious)"""
     role: discord.Role = member.guild.get_role(int(role_id))

--- a/test/bot/test_on_raw_reaction_add.py
+++ b/test/bot/test_on_raw_reaction_add.py
@@ -52,7 +52,7 @@ class TestOnRawReactionAdd(aiounittest.AsyncTestCase):
         self.lecture = lecture
 
     async def test_on_raw_reaction_add_adds_role_when_reacted_with_white_check_mark_on_lecture_embed(self):
-        reaction, emoji, member, role = (self.reaction, self.emoji, self.member, self.role)
+        reaction, emoji, member, role = self.reaction, self.emoji, self.member, self.role
         # user reacted with WHITE_CHECK_MARK
         emoji.name = WHITE_CHECK_MARK
         # user reacted to message with message id 5678
@@ -70,7 +70,7 @@ class TestOnRawReactionAdd(aiounittest.AsyncTestCase):
         member.add_roles.assert_called_once_with(role)
 
     async def test_on_raw_reaction_add_does_not_add_role_when_not_reacted_with_white_check_mark_on_lecture_embed(self):
-        reaction, emoji, member, role = (self.reaction, self.emoji, self.member, self.role)
+        reaction, emoji, member, role = self.reaction, self.emoji, self.member, self.role
         # user reacted with something else than WHITE_CHECK_MARK
         emoji.name = WHITE_CHECK_MARK + "xx"  # TODO Create another actual emoji unicode character for usage here
         # user reacted to message with message id 5678

--- a/test/bot/test_on_raw_reaction_add.py
+++ b/test/bot/test_on_raw_reaction_add.py
@@ -52,8 +52,7 @@ class TestOnRawReactionAdd(aiounittest.AsyncTestCase):
         self.lecture = lecture
 
     async def test_on_raw_reaction_add_adds_role_when_reacted_with_white_check_mark_on_lecture_embed(self):
-        reaction, emoji, member, role, lecture = \
-            (self.reaction, self.emoji, self.member, self.role, self.lecture)
+        reaction, emoji, member, role = (self.reaction, self.emoji, self.member, self.role)
         # user reacted with WHITE_CHECK_MARK
         emoji.name = WHITE_CHECK_MARK
         # user reacted to message with message id 5678
@@ -71,8 +70,7 @@ class TestOnRawReactionAdd(aiounittest.AsyncTestCase):
         member.add_roles.assert_called_once_with(role)
 
     async def test_on_raw_reaction_add_does_not_add_role_when_not_reacted_with_white_check_mark_on_lecture_embed(self):
-        reaction, emoji, member, role, lecture = \
-            (self.reaction, self.emoji, self.member, self.role, self.lecture)
+        reaction, emoji, member, role = (self.reaction, self.emoji, self.member, self.role)
         # user reacted with something else than WHITE_CHECK_MARK
         emoji.name = WHITE_CHECK_MARK + "xx"  # TODO Create another actual emoji unicode character for usage here
         # user reacted to message with message id 5678
@@ -86,7 +84,7 @@ class TestOnRawReactionAdd(aiounittest.AsyncTestCase):
         member.add_roles.assert_not_called()
 
     async def test_on_raw_reaction_add_ignores_reaction_from_bot(self):
-        reaction, emoji, member, lecture = self.reaction, self.emoji, self.member, self.lecture
+        reaction, emoji, member = self.reaction, self.emoji, self.member
         # the reaction was from the bot itself
         reaction.user_id = self.bot.user.id
         # assume reaction was WHITE_CHECK_MARK

--- a/test/bot/test_on_raw_reaction_remove.py
+++ b/test/bot/test_on_raw_reaction_remove.py
@@ -52,7 +52,7 @@ class TestOnRawReactionRemove(aiounittest.AsyncTestCase):
         self.lecture = lecture
 
     async def test_on_raw_reaction_remove_removes_role_when_removed_white_check_mark_reaction_from_lecture_embed(self):
-        reaction, emoji, member, role = (self.reaction, self.emoji, self.member, self.role)
+        reaction, emoji, member, role = self.reaction, self.emoji, self.member, self.role
         # user removed reaction WHITE_CHECK_MARK
         emoji.name = WHITE_CHECK_MARK
         # user reacted to message with message id 5678

--- a/test/bot/test_on_raw_reaction_remove.py
+++ b/test/bot/test_on_raw_reaction_remove.py
@@ -16,17 +16,17 @@ class TestOnRawReactionRemove(aiounittest.AsyncTestCase):
     @mock.patch('discord.Emoji', autospec=True)
     @mock.patch('discord.Guild', autospec=True)
     @mock.patch('discord.RawReactionActionEvent', autospec=True)
+    @mock.patch('src.util.lecture.Lecture', autospec=True)
     @mock.patch('src.bot.BotClient', autospec=True)
-    def setUp(self, bot, reaction, guild, emoji, member, role):
+    def setUp(self, bot, lecture, reaction, guild, emoji, member, role):
         bot.logger = mock.Mock()
         bot.user.id = '00000'
         self.bot = bot
-        # setup the lecture mock we will receive when calling bot#get_lecture_of_message_id
-        lecture_mock = mock.MagicMock()
-        # when calling lecture['role'], we want to get the "role id"
-        lecture_mock.__getitem__.return_value = '1234'
+        # when calling lecture.role, we want to get the "role id"
+        lecture.role = '1234'
+        lecture.embed_title = 'title'  # not needed to test behaviour but to fix unimportant AttributeError during test
         # bot#get_lecture_of_message_id should return the mocked lecture
-        self.bot.get_lecture_of_message_id.return_value = lecture_mock
+        self.bot.get_lecture_of_message_id.return_value = lecture
         """member#remove_roles should always be awaitable even though we are not always expecting that this function will
         be called. The reason for this that we don't want to couple our test to tightly with the code; expecting more
         from the SUT (system under test) than we are testing.
@@ -49,11 +49,11 @@ class TestOnRawReactionRemove(aiounittest.AsyncTestCase):
         self.emoji = emoji
         self.member = member
         self.role = role
-        self.lecture_mock = lecture_mock
+        self.lecture = lecture
 
     async def test_on_raw_reaction_remove_removes_role_when_removed_white_check_mark_reaction_from_lecture_embed(self):
-        reaction, emoji, member, role, lecture_mock = \
-            (self.reaction, self.emoji, self.member, self.role, self.lecture_mock)
+        reaction, emoji, member, role, lecture = \
+            (self.reaction, self.emoji, self.member, self.role, self.lecture)
         # user removed reaction WHITE_CHECK_MARK
         emoji.name = WHITE_CHECK_MARK
         # user reacted to message with message id 5678
@@ -65,8 +65,6 @@ class TestOnRawReactionRemove(aiounittest.AsyncTestCase):
 
         # assert that we tried to find the lecture via the message id
         self.bot.get_lecture_of_message_id.assert_called_once_with('5678')
-        # assert that we accessed the role in the found lecture
-        lecture_mock.__getitem__.assert_called_with('role')
         # assert that we got the role from the guild with its id as integer
         member.guild.get_role.assert_called_once_with(1234)
         # assert that we removed the role from the member
@@ -88,7 +86,7 @@ class TestOnRawReactionRemove(aiounittest.AsyncTestCase):
         member.add_roles.assert_not_called()
 
     async def test_on_raw_reaction_remove_ignores_reaction_from_bot(self):
-        reaction, emoji, member, lecture_mock = self.reaction, self.emoji, self.member, self.lecture_mock
+        reaction, emoji, member, lecture = self.reaction, self.emoji, self.member, self.lecture
         # the reaction was from the bot itself
         reaction.user_id = self.bot.user.id
         # assume reaction was WHITE_CHECK_MARK
@@ -100,6 +98,5 @@ class TestOnRawReactionRemove(aiounittest.AsyncTestCase):
 
         # assert that none of the following methods were called:
         self.bot.get_lecture_of_message_id.assert_not_called()
-        lecture_mock.__getitem__.assert_not_called()
         member.guild.get_role.assert_not_called()
         member.add_roles.assert_not_called()

--- a/test/bot/test_on_raw_reaction_remove.py
+++ b/test/bot/test_on_raw_reaction_remove.py
@@ -52,8 +52,7 @@ class TestOnRawReactionRemove(aiounittest.AsyncTestCase):
         self.lecture = lecture
 
     async def test_on_raw_reaction_remove_removes_role_when_removed_white_check_mark_reaction_from_lecture_embed(self):
-        reaction, emoji, member, role, lecture = \
-            (self.reaction, self.emoji, self.member, self.role, self.lecture)
+        reaction, emoji, member, role = (self.reaction, self.emoji, self.member, self.role)
         # user removed reaction WHITE_CHECK_MARK
         emoji.name = WHITE_CHECK_MARK
         # user reacted to message with message id 5678
@@ -86,7 +85,7 @@ class TestOnRawReactionRemove(aiounittest.AsyncTestCase):
         member.add_roles.assert_not_called()
 
     async def test_on_raw_reaction_remove_ignores_reaction_from_bot(self):
-        reaction, emoji, member, lecture = self.reaction, self.emoji, self.member, self.lecture
+        reaction, emoji, member = self.reaction, self.emoji, self.member
         # the reaction was from the bot itself
         reaction.user_id = self.bot.user.id
         # assume reaction was WHITE_CHECK_MARK


### PR DESCRIPTION
This PR adds type annotations to all functions in src.

Running `mypy src/` with the following config leads to 
```
Success: no issues found in 13 source files
```

Config:
```ini
[mypy]
ignore_missing_imports = True
disallow_untyped_defs = True
```

This already helped to find some issues in the code: The tests were sending false positives because they were not updated since https://github.com/ekzyis/physicsbot/commit/c3d58763c5ddcc3f65085eb3fd219b938d5d084c

The issue was found after annotating a part of the code which made PyCharm aware that the class Lecture does not have a \_\_getitem__ method:

![2020-05-22-231756_1366x768_scrot_crop](https://user-images.githubusercontent.com/27162016/82710152-7cb2de00-9c82-11ea-9446-1f1ab0fa46ad.png)


close #46 

